### PR TITLE
Potential fix for code scanning alert no. 1: Implicit narrowing conversion in compound assignment

### DIFF
--- a/kriolos-opos-hardware/src/main/java/com/openbravo/pos/printer/ticket/PrintItemLine.java
+++ b/kriolos-opos-hardware/src/main/java/com/openbravo/pos/printer/ticket/PrintItemLine.java
@@ -80,7 +80,7 @@ public class PrintItemLine implements PrintItem {
     public void draw(Graphics2D g, int x, int y, int width) {
 
         MyPrinterState ps = new MyPrinterState(textsize);
-        float left = x;
+        double left = x;
         for (int i = 0; i < m_atext.size(); i++) {
             StyledText t = m_atext.get(i);
             g.setFont(ps.getFont(font, t.style));


### PR DESCRIPTION
Potential fix for [https://github.com/poolborges/unicenta-pos/security/code-scanning/1](https://github.com/poolborges/unicenta-pos/security/code-scanning/1)

To fix the problem, we need to ensure that the type of the left-hand side of the compound assignment is at least as wide as the type of the right-hand side. In this case, we should change the type of `left` from `float` to `double` to match the type returned by `getWidth()`. This will prevent any implicit narrowing conversion and preserve the precision of the calculation.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
